### PR TITLE
Add 'base' to the gson and jowli formatters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Formats
 JSON
 ```json
 {
+  "base" : "basic", /* basic, basicwithimages, relaxed, none, or null */
   "tags" : ["a","b"],
   "attributes" : {
     "blockquote": ["cite"]
@@ -82,11 +83,26 @@ externalized configuration friendly format.
 
 ```
 (all on one line)
+b:b;    /* note this can be b=basic, i=basicwithimages, n=none, r=relaxed */
 t:a,b;
 a:blockquote[cite],a[href,rel];
 e:a[rel:nofollow];
 p:a[href:[ftp,http,https,mailto]]
 ```
+
+All directives are optional and additive.  In the case of 'b', the last one wins.  What? Basically...
+
+```
+t:a,b
+```
+
+is equivalent to :
+
+```
+t:a;t:b
+```
+
+
 LICENSE
 -------
 MIT

--- a/core/src/main/java/io/shick/jsoup/BaseFactories.java
+++ b/core/src/main/java/io/shick/jsoup/BaseFactories.java
@@ -1,0 +1,34 @@
+package io.shick.jsoup;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.jsoup.safety.Whitelist;
+
+/**
+ * Created by tshick on 11/17/16.
+ */
+public class BaseFactories {
+  
+
+  public static final Map<String, Supplier<Whitelist>> FACTORIES;
+
+  public static final String BASIC = "basic";
+
+  public static final String BASICWITHIMAGES = "basicwithimages";
+
+  public static final String RELAXED = "relaxed";
+
+  public static final String NONE = "none";
+  static {
+    Map<String,Supplier<Whitelist>> m = new HashMap<>();
+    m.put(BASIC, Whitelist::basic);
+    m.put(BASICWITHIMAGES, Whitelist::basicWithImages);
+    m.put(RELAXED, Whitelist::relaxed);
+    m.put(NONE, Whitelist::none);
+    FACTORIES = Collections.unmodifiableMap(m);
+  }
+
+}

--- a/core/src/main/java/io/shick/jsoup/MutableWhitelistConfiguration.java
+++ b/core/src/main/java/io/shick/jsoup/MutableWhitelistConfiguration.java
@@ -1,11 +1,22 @@
 package io.shick.jsoup;
 
+import org.jsoup.safety.Whitelist;
+
 /**
  * <p>MutableWhitelistConfiguration interface.</p>
  *
  * @author Trever Shick - trever@shick.io
  */
 public interface MutableWhitelistConfiguration extends WhitelistConfiguration {
+
+  /**
+   * <p>Sets the base whitelist to use when configuring a {@link Whitelist}, 'none' is the default value.</p>
+   * 
+   * @param name an instance of whitelist to use as the base whitelist
+   * @return a {@link io.shick.jsoup.MutableWhitelistConfiguration} object.
+   */
+  MutableWhitelistConfiguration base(String name);
+  
   /**
    * <p>Add an allowed tag to the configuration</p>
    *

--- a/core/src/main/java/io/shick/jsoup/WhitelistConfiguration.java
+++ b/core/src/main/java/io/shick/jsoup/WhitelistConfiguration.java
@@ -15,6 +15,11 @@ import org.jsoup.safety.Whitelist;
 public interface WhitelistConfiguration {
 
   /**
+   * @return the name of the 'base' whitelist used when {@link #whitelist()} is called.
+   */
+  String base();
+
+  /**
    * <p><em>fn</em> will be called once for each allowed tag.</p>
    *
    * @param fn (non null) a {@link java.util.function.Consumer} object.
@@ -134,4 +139,5 @@ public interface WhitelistConfiguration {
    * @return a configured {@link org.jsoup.safety.Whitelist} object.
    */
   Whitelist whitelist();
+
 }

--- a/core/src/test/java/io/shick/jsoup/BasicWhitelistConfigurationTest.java
+++ b/core/src/test/java/io/shick/jsoup/BasicWhitelistConfigurationTest.java
@@ -23,6 +23,11 @@ public class BasicWhitelistConfigurationTest {
 
   final BasicWhitelistConfiguration config = new BasicWhitelistConfiguration();
 
+  @Test(expected = IllegalStateException.class)
+  public void invalidBase() {
+    config.base("invalid").whitelist();
+  }
+  
   @Test
   public void tags() {
     assertThat(config.allowsTag("a"), is(false));
@@ -166,6 +171,7 @@ public class BasicWhitelistConfigurationTest {
   public void whitelist() {
 
     final Whitelist whitelist = new BasicWhitelistConfiguration()
+      .base("none")
       .allowTag("a")
       .allowTag("b")
       .allowAttribute("blockquote", "cite")

--- a/gson/src/test/java/io/shick/jsoup/gson/GsonFormatterTest.java
+++ b/gson/src/test/java/io/shick/jsoup/gson/GsonFormatterTest.java
@@ -58,6 +58,7 @@ public class GsonFormatterTest {
   public void format() throws ParseException {
     final String json = "\n"
       + "{\n"
+      + "  \"base\" : \"none\",\n"
       + "  \"tags\" : [\"a\",\"b\"],\n"
       + "  \"attributes\" : {\n"
       + "    \"blockquote\": [\"cite\"]\n"
@@ -86,6 +87,7 @@ public class GsonFormatterTest {
   public void emptyCollectionsAreNull() throws ParseException {
     final String json = "\n"
       + "{\n"
+      + "  \"base\" : null,\n"
       + "  \"tags\" : [],\n"
       + "  \"attributes\" : {},\n"
       + "  \"enforcedAttributes\": {},\n"

--- a/gson/src/test/java/io/shick/jsoup/gson/GsonParserTest.java
+++ b/gson/src/test/java/io/shick/jsoup/gson/GsonParserTest.java
@@ -44,6 +44,16 @@ public class GsonParserTest {
   }
 
   @Test
+  public void parseBase() throws ParseException {
+    String json = "{ \"base\" : \"basic\" }";
+
+    final WhitelistConfiguration c = new GsonParser().parse(json);
+    assertThat(c.base(), is("basic"));
+    verifyNoNpes(c);
+  }
+
+
+  @Test
   public void parseAttributes() throws ParseException {
     String json = "{"
       + "  \"attributes\" : {\n"
@@ -149,6 +159,7 @@ public class GsonParserTest {
   public void whitelist() throws ParseException {
     final String json = "\n"
       + "{\n"
+      + "  \"base\" : \"none\",\n"
       + "  \"tags\" : [\"a\",\"b\"],\n"
       + "  \"attributes\" : {\n"
       + "    \"blockquote\": [\"cite\"]\n"

--- a/gson/src/test/java/io/shick/jsoup/gson/GsonWhitelistConfigurationTest.java
+++ b/gson/src/test/java/io/shick/jsoup/gson/GsonWhitelistConfigurationTest.java
@@ -1,5 +1,6 @@
 package io.shick.jsoup.gson;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -206,6 +207,33 @@ public class GsonWhitelistConfigurationTest {
     assertThat(stripped(json), is(stripped(actual)));
     assertThat(config, is(config2));
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void invalidBase() throws ParseException {
+    String text = "{ \"base\":\"basic2\" }"; // use 'basic'
+    final WhitelistConfiguration c = new GsonParser().parse(text);
+    c.whitelist();
+  }
+  
+  @Test
+  public void baseCanBeSpecified() throws ParseException {
+    String text = "{ \"base\":\"basic\" }"; // use 'basic'
+    final WhitelistConfiguration c = new GsonParser().parse(text);
+
+    Whitelist wl = c.whitelist();
+    Whitelist basic = Whitelist.basic();
+    String html = "<a href=\"http://x\">To X</a>";
+    assertThat("Basic will add rel=nofollow to links.",
+      Jsoup.clean(html, wl),
+      is(Jsoup.clean(html, basic)));
+    assertThat("Basic will add rel=nofollow to links.",
+      Jsoup.clean(html, wl),
+      containsString("nofollow"));
+
+
+    assertThat(c.toString(), is(new GsonFormatter().format(c)));
+  }
+
 
   private String stripped(String json) {
     return json.replaceAll("[\\n\\s]", "");

--- a/jowli/src/main/java/io/shick/jsoup/jowli/JowliMLFormatter.java
+++ b/jowli/src/main/java/io/shick/jsoup/jowli/JowliMLFormatter.java
@@ -2,11 +2,14 @@ package io.shick.jsoup.jowli;
 
 import static java.util.Objects.requireNonNull;
 
+import io.shick.jsoup.BaseFactories;
 import io.shick.jsoup.WhitelistConfiguration;
 import io.shick.jsoup.WhitelistConfigurationFormatter;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicReference;
@@ -18,6 +21,24 @@ import java.util.function.Consumer;
  * @author Trever Shick - trever@shick.io
  */
 public class JowliMLFormatter implements WhitelistConfigurationFormatter {
+  private static final Map<String,Character> FACTORY_TO_JOWLI_LETTER;
+
+  public static final char LETTER_BASIC = 'b';
+
+  public static final char LETTER_BASICWITHIMAGES = 'i';
+
+  public static final char LETTER_RELAXED = 'r';
+
+  public static final char LETTER_NONE = 'n';
+
+  static {
+    Map<String,Character> m = new HashMap<>();
+    m.put(BaseFactories.BASIC, LETTER_BASIC);
+    m.put(BaseFactories.BASICWITHIMAGES, LETTER_BASICWITHIMAGES);
+    m.put(BaseFactories.RELAXED, LETTER_RELAXED);
+    m.put(BaseFactories.NONE, LETTER_NONE);
+    FACTORY_TO_JOWLI_LETTER = m;
+  }
 
   /**
    * {@inheritDoc}
@@ -30,6 +51,7 @@ public class JowliMLFormatter implements WhitelistConfigurationFormatter {
 
   private void root(WhitelistConfiguration config, Consumer<CharSequence> c) {
     final StringJoiner sj = new StringJoiner(";");
+    baseDirective(config, sj::add);
     tagsDirective(config, sj::add);
     allowedAttributesDirective(config, sj::add);
     enforcedAttributesDirective(config, sj::add);
@@ -113,6 +135,19 @@ public class JowliMLFormatter implements WhitelistConfigurationFormatter {
     config.allowedTags(sj::add);
     if (sj.length() > 0) {
       c.accept(new StringBuilder("t:").append(sj.toString()));
+    }
+  }
+
+  /**
+   * "b:b"
+   *
+   * @param config
+   * @param c
+   */
+  private void baseDirective(WhitelistConfiguration config, Consumer<CharSequence> c) {
+    String factory = config.base();
+    if (factory != null) {
+      c.accept(new StringBuilder("b:").append(FACTORY_TO_JOWLI_LETTER.get(factory)));
     }
   }
 

--- a/jowli/src/main/java/io/shick/jsoup/jowli/JowliMLParser.java
+++ b/jowli/src/main/java/io/shick/jsoup/jowli/JowliMLParser.java
@@ -1,15 +1,22 @@
 package io.shick.jsoup.jowli;
 
+import static io.shick.jsoup.jowli.JowliMLFormatter.LETTER_BASIC;
+import static io.shick.jsoup.jowli.JowliMLFormatter.LETTER_BASICWITHIMAGES;
+import static io.shick.jsoup.jowli.JowliMLFormatter.LETTER_NONE;
+import static io.shick.jsoup.jowli.JowliMLFormatter.LETTER_RELAXED;
 import static org.codehaus.jparsec.Parsers.between;
+import static org.codehaus.jparsec.Parsers.or;
 import static org.codehaus.jparsec.Parsers.sequence;
 import static org.codehaus.jparsec.Scanners.isChar;
 
+import io.shick.jsoup.BaseFactories;
 import io.shick.jsoup.WhitelistConfiguration;
 import io.shick.jsoup.WhitelistConfigurationParser;
 import io.shick.jsoup.WhitelistConfigurationParserFactory;
 import io.shick.jsoup.jowli.ast.AllowedAttributes;
 import io.shick.jsoup.jowli.ast.AllowedTags;
 import io.shick.jsoup.jowli.ast.Attr;
+import io.shick.jsoup.jowli.ast.BaseWhitelist;
 import io.shick.jsoup.jowli.ast.ConfigConsumer;
 import io.shick.jsoup.jowli.ast.EnforcedAttributes;
 import io.shick.jsoup.jowli.ast.Prot;
@@ -119,13 +126,26 @@ public final class JowliMLParser implements WhitelistConfigurationParser {
       COLON,
       commaed(TAG_ATTR_PROTOCOLS),
       (__, ___, v) -> new Protocols(v));
+  
+  static final Parser<BaseWhitelist> BASE_DIRECTIVE =
+    sequence(
+      isChar('b'),
+      COLON,
+      or(
+        isChar(LETTER_BASIC).retn(BaseFactories.BASIC),
+        isChar(LETTER_BASICWITHIMAGES).retn(BaseFactories.BASICWITHIMAGES),
+        isChar(LETTER_RELAXED).retn(BaseFactories.RELAXED),
+        isChar(LETTER_NONE).retn(BaseFactories.NONE)),
+      (__, ___, b) -> new BaseWhitelist(b)
+    );
 
   static final Parser<List<ConfigConsumer>> ROOT =
     Parsers.<ConfigConsumer>or(
       ALLOWED_ATTRIBUTES_DIRECTIVE,
       ENFORCED_ATTRIBUTES_DIRECTIVE,
       PROTOCOLS_DIRECTIVE,
-      ALLOWED_TAGS_DIRECTIVE).sepBy(isChar(';'));
+      ALLOWED_TAGS_DIRECTIVE,
+      BASE_DIRECTIVE).sepBy(isChar(';'));
 
   /**
    * {@inheritDoc}

--- a/jowli/src/main/java/io/shick/jsoup/jowli/ast/BaseWhitelist.java
+++ b/jowli/src/main/java/io/shick/jsoup/jowli/ast/BaseWhitelist.java
@@ -1,0 +1,29 @@
+package io.shick.jsoup.jowli.ast;
+
+import io.shick.jsoup.MutableWhitelistConfiguration;
+
+import java.util.List;
+
+/**
+ * <p>BaseWhitelist class.</p>
+ *
+ * @author Trever Shick - trever@shick.io
+ */
+public final class BaseWhitelist extends ValueObject<String> implements ConfigConsumer {
+  /**
+   * <p>Constructor for BaseWhitelist.</p>
+   *
+   * @param v a {@link List} object.
+   */
+  public BaseWhitelist(String v) {
+    super(v);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void accept(MutableWhitelistConfiguration c) {
+    c.base(value());
+  }
+}

--- a/jowli/src/test/java/io/shick/jsoup/jowli/JowliMLFormatterTest.java
+++ b/jowli/src/test/java/io/shick/jsoup/jowli/JowliMLFormatterTest.java
@@ -21,9 +21,9 @@ public class JowliMLFormatterTest {
   @Test
   public void fullCircleWithNothing() throws ParseException {
     WhitelistConfiguration wlc = new BasicWhitelistConfiguration();
-    final String json = new JowliMLFormatter().format(wlc).toString();
-    assertThat(json, is(""));
-    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(json);
+    final String jowliml = new JowliMLFormatter().format(wlc).toString();
+    assertThat(jowliml, is(""));
+    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(jowliml);
     assertThat(wlc, is(wlc2));
   }
 
@@ -32,9 +32,9 @@ public class JowliMLFormatterTest {
     WhitelistConfiguration wlc = new BasicWhitelistConfiguration()
       .allowTag("blockquote")
       .allowTag("b");
-    final String json = new JowliMLFormatter().format(wlc).toString();
-    assertThat(json, is("t:blockquote,b"));
-    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(json);
+    final String jowliml = new JowliMLFormatter().format(wlc).toString();
+    assertThat(jowliml, is("t:blockquote,b"));
+    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(jowliml);
     assertThat(wlc, is(wlc2));
   }
 
@@ -43,9 +43,9 @@ public class JowliMLFormatterTest {
     WhitelistConfiguration wlc = new BasicWhitelistConfiguration()
       .allowAttribute("blockquote", "cite")
       .allowAttribute("a", "href");
-    final String json = new JowliMLFormatter().format(wlc).toString();
-    assertThat(json, is("a:a[href],blockquote[cite]"));
-    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(json);
+    final String jowliml = new JowliMLFormatter().format(wlc).toString();
+    assertThat(jowliml, is("a:a[href],blockquote[cite]"));
+    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(jowliml);
     assertThat(wlc, is(wlc2));
   }
 
@@ -53,9 +53,9 @@ public class JowliMLFormatterTest {
   public void fullCircleWithEnforcedAttributes() throws ParseException {
     WhitelistConfiguration wlc = new BasicWhitelistConfiguration()
       .enforceAttribute("a", "rel", "nofollow");
-    final String json = new JowliMLFormatter().format(wlc).toString();
-    assertThat(json, is("e:a[rel:nofollow]"));
-    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(json);
+    final String jowliml = new JowliMLFormatter().format(wlc).toString();
+    assertThat(jowliml, is("e:a[rel:nofollow]"));
+    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(jowliml);
     assertThat(wlc, is(wlc2));
   }
 
@@ -64,11 +64,18 @@ public class JowliMLFormatterTest {
     final WhitelistConfiguration wlc = new BasicWhitelistConfiguration()
       .allowProtocol("a", "href", "mailto");
 
-    final String json = new JowliMLFormatter().format(wlc).toString();
-    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(json);
+    final String jowliml = new JowliMLFormatter().format(wlc).toString();
+    final WhitelistConfiguration wlc2 = new JowliMLParser().parse(jowliml);
 
-    assertThat(json, is("p:a[href:[mailto]]"));
+    assertThat(jowliml, is("p:a[href:[mailto]]"));
     assertThat(wlc, is(wlc2));
+  }
+
+  @Test
+  public void formatJustBase() throws ParseException {
+    final String jowliml = "b:r";
+
+    verifyInAndOutAreSame(jowliml);
   }
 
   @Test
@@ -81,7 +88,7 @@ public class JowliMLFormatterTest {
   @Test
   public void formatAll() throws ParseException {
     final String jowliml
-      = "t:a,b;a:a[href,rel],blockquote[cite];e:a[rel:nofollow,x:y];p:a[z:[d],href:[ftp,http,https]]";
+      = "b:n;t:a,b;a:a[href,rel],blockquote[cite];e:a[rel:nofollow,x:y];p:a[z:[d],href:[ftp,http,https]]";
 
     verifyInAndOutAreSame(jowliml);
   }

--- a/jowli/src/test/java/io/shick/jsoup/jowli/JowliMLWhitelistConfigurationTest.java
+++ b/jowli/src/test/java/io/shick/jsoup/jowli/JowliMLWhitelistConfigurationTest.java
@@ -1,5 +1,6 @@
 package io.shick.jsoup.jowli;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -7,18 +8,48 @@ import io.shick.jsoup.WhitelistConfiguration;
 
 import java.text.ParseException;
 
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Whitelist;
 import org.junit.Test;
 
-/**
- * Created by tshick on 11/11/16.
- */
 public class JowliMLWhitelistConfigurationTest {
 
   @Test
   public void toStringFormatsJowli() throws ParseException {
-    String text = "t:a,b,c;a:dog[a,b,c]";
+    String text = "b:n;t:a,b,c;a:dog[a,b,c]";
     final WhitelistConfiguration c = new JowliMLParser().parse(text);
 
     assertThat(c.toString(), is(new JowliMLFormatter().format(c)));
   }
+
+  @Test
+  public void baseCanBeSpecified() throws ParseException {
+    String text = "b:b"; // use 'basic'
+    final WhitelistConfiguration c = new JowliMLParser().parse(text);
+
+    Whitelist wl = c.whitelist();
+    Whitelist basic = Whitelist.basic();
+    String html = "<a href=\"http://x\">To X</a>";
+    assertThat("Basic will add rel=nofollow to links.",
+      Jsoup.clean(html, wl),
+      is(Jsoup.clean(html, basic)));
+    assertThat("Basic will add rel=nofollow to links.",
+      Jsoup.clean(html, wl),
+      containsString("nofollow"));
+
+
+    assertThat(c.toString(), is(new JowliMLFormatter().format(c)));
+  }
+
+  @Test
+  public void rootAdditivity() throws ParseException {
+    String text = "b:i;t:a,b,c;a:dog[a,b,c]";
+    String textAdditive = "b:n;b:i;t:a;t:b;t:c;a:dog[a];a:dog[b];a:dog[c]";
+
+    String jowli = new JowliMLParser().parse(text).toString();
+    String jowliAdditive = new JowliMLParser().parse(textAdditive).toString();
+
+    assertThat(jowli, is(jowliAdditive));
+  }
+
 }


### PR DESCRIPTION
This allows users to specify a starting point for whitelist() like 'basic', 'basicwithimages', 'none' or 'relaxed'.

Fixes #9